### PR TITLE
`SimpleUncaughtError` inherits from `UncaughtErrors`.

### DIFF
--- a/lib/providers/SimpleUncaughtErrors.js
+++ b/lib/providers/SimpleUncaughtErrors.js
@@ -1,9 +1,17 @@
-export default class SimpleUncaughtErrors {
+import UncaughtErrors from "./UncaughtErrors";
+import { logger } from "../decorators";
+
+@logger("SimpleUncaught")
+export default class SimpleUncaughtErrors extends UncaughtErrors {
     listen() {
         global.onerror = (error) => {
             this.logger.error("Uncaught Error!");
             this.logger.error(error);
             return true;
         };
+    }
+
+    _createPresentedError(error) {
+        return error;
     }
 }


### PR DESCRIPTION
`createPresentedError` will simply return the error. Client apps will implement this method in more advanced fashion. Maybe create errors that can show themselves in a dialog, or inline..