### PR TITLE
Do not create multiple Test App instances.

### DIFF
--- a/lib/TestApp.js
+++ b/lib/TestApp.js
@@ -13,7 +13,7 @@ class TestApp extends ProvidedAppDelegate {
     run(delegateHooks = {}) {
         _.extend(this, delegateHooks);
         var appArgs = defaultsWithDelegate(this);
-        App.run(...appArgs);
+        _.once(App.run.bind(null, ...appArgs));
     }
     registerAction(name, actionCmd) {
         this.actions[name] = actionCmd;


### PR DESCRIPTION
Hey @pbouzakis what do you think of this? We're trying to run our @app test specs and getting this error: 

```
[Error: App can only have one instance at a time. Try App.terminate() first.]
```

@jfkhoury thinks we got this error in the past and found a way around it, though none of us can remember what it was. In looking at marauder it looks like our app components never ran tests that relied on Test.App
